### PR TITLE
Correct the link to chapter-handbook

### DIFF
--- a/pages/chapters/info.md
+++ b/pages/chapters/info.md
@@ -1,4 +1,4 @@
 ### Important Links
-* [Chapter Handbook](/www-policy/rules-of-procedure/chapter-handbook)
+* [Chapter Handbook](/www-policy/operational/chapter-handbook-existing)
 * [Start a New Chapter](https://owasporg.atlassian.net/servicedesk/customer/portal/7/group/18/create/73)
 * [OWASP Meetup](https://owasp.meetup.com)


### PR DESCRIPTION
Current chapter handbook link results in 404 error and relevant location is not available in [GitHub repository](https://github.com/OWASP/www-policy). This PR corrects the link to the currently existing chapter-handbook at:  https://github.com/OWASP/www-policy/blob/master/operational/chapter-handbook-existing.md