### PR TITLE
Server based headers instead of meta

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,3 +2,8 @@ remote_theme: "owasp/www--site-theme"
 plugins:
  - jekyll-include-cache-0.2.0
  - jekyll-remote-theme
+webrick:
+  headers:
+    X-XSS-Options: 1; mode=block
+    X-Frame-Options: SAMEORIGIN
+    X-Content-Type-Options: nosniff


### PR DESCRIPTION
Usage of meta is not advisable for setting headers. Will be removing the meta headers from www--site-theme also, once this pull request is approved.