### PR TITLE
add basic steps to run site locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,33 @@
 # owasp.github.io
 OWASP Foundation main site repository
 
+### local development
+
+since there's no Gemfile included with this repo at the moment, the easiest thing
+to do is to fake a new jekyll install by running the following:
+
+```
+$ bundle exec jekyll new --force --skip-bundle
+$ bundle install
+$ bundle exec jekyll serve
+```
+
+unfortunately, because the local build is currently broken, you'll see the following
+error:
+
+```
+  Liquid Exception: Could not locate the included file 'news-events.html' in any of ["/home/adam/Desktop/projects/owasp.github.io/_includes", "/home/adam/.rvm/gems/ruby-2.6.3/gems/minima-2.5.1/_includes"]. Ensure it exists in one of those directories and, if it is a symlink, does not point outside your site source. in index.md
+```
+
+to resolve this, just delete the following line from `index.md`:
+
+`{% include news-events.html %}`
+
+then run `bundle exec jekyll serve` again, and you should be able to access the
+site at `localhost:4000`. It still doesn't look exactly right, and I assume this
+is because some of the downloaded assets are hosted at relative paths from the main
+domain, so aren't available in this source code.
+
 [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]
 
 The website is licensed under a [Creative Commons Attribution-ShareAlike 4.0


### PR DESCRIPTION
the site has no `Gemfile` available, so currently has to be reverse engineered to
run locally. Also, due to the reference to `news-events.html` in `index.md`, the
site won't actually run until that is deleted, at least for the time being.