### PR TITLE
Add initial friendly URLs for WSTG and ZAP

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,3 +2,4 @@ remote_theme: "owasp/www--site-theme"
 plugins:
  - jekyll-include-cache-0.2.0
  - jekyll-remote-theme
+ - jekyll-redirect-from

--- a/redirects/wstg.md
+++ b/redirects/wstg.md
@@ -1,0 +1,9 @@
+---
+
+title: WSTG Redirect
+type: tool
+permalink: /wstg
+redirect_to: /www-project-web-security-testing-guide/
+
+---
+

--- a/redirects/zap.md
+++ b/redirects/zap.md
@@ -1,0 +1,9 @@
+---
+
+title: ZAP Redirect
+type: tool
+permalink: /zap
+redirect_to: /www-project-zap/
+
+---
+


### PR DESCRIPTION
Add  `redirects` directory which contains simple markdown files with minimal front mater, permalinking friendly URLs like `owasp.org/zap` and `redirect_to: www-project-zap`, etc (This facilitates all the redirects existing in a single location for simple maintenance.)

Leverages: https://github.com/jekyll/jekyll-redirect-from (which is confirmed supported: https://pages.github.com/versions/)

Basically at runtime it establishes content with 'link rel canonical' along with meta refresh. From the little reading I've done it is search engine friendly and they'll pickup the updates after a few days (or so I read).

Tested locally with a setup similar to: https://github.com/OWASP/www-project-web-security-testing-guide/#getting-started

Once this is approved conceptually, I can tackle some others (All the flagships maybe, and my local chapter). Also my testing has shown that it's possible to handle multiple "friendly" URLs (ex: if Top 10 wanted `/top10`, `/topten`, and `/t10` or something like that). [Other projects/chapters can do their own PRs later.]