### PR TITLE
Grammer Fixes

### DIFF
--- a/_includes/featured_chapter.md
+++ b/_includes/featured_chapter.md
@@ -3,4 +3,4 @@
 
 <a><img src="/assets/images/content/bay-area2.jpg" alt="Bay Area Chapter Meeting"></a>
 
-Hosted at some of most iconic technology companies in the world, the Bay Area chapter is one of the Foundation's largest and most active. This month they are hosting a Hacker Day and monthly meetups in San Francisco at Insight Engines and in South Bay at EBay. Usually the agenda includes three proactive and interesting talks, lots of interesting people to meet, and great food. The Bay Area Chapter also participates in planning AppSec California.
+Hosted at some of the most iconic technology companies in the world, the Bay Area chapter is one of the Foundation's largest and most active. This month they are hosting a Hacker Day and monthly meetups in San Francisco at Insight Engines and in South Bay at eBay. Usually, the agenda includes three proactive and interesting talks, lots of interesting people to meet, and great food. The Bay Area Chapter also participates in planning AppSec California.


### PR DESCRIPTION
- In "Hosted at some of most iconic technology companies in the world" – the word "the" needs to be added before "most"
- In "in San Francisco at Insight Engines and in South Bay at EBay" – "EBay" should be spelled "eBay"
- In "Usually the agenda includes" – "Usually" should be followed by a comma