### PR TITLE
Fixed the link to secure flag

### DIFF
--- a/pages/membership.md
+++ b/pages/membership.md
@@ -255,7 +255,7 @@ permalink: /membership/
         <li>Training discounts</li>
         <li>OWASP email address and Google Workplace access</li>
         <li>A vote in our OWASP Global Board elections</li>
-        <li>Hands-on application security training through the [SecureFlag Platform](https://www.secureflag.com/owasp.html)</li> 
+        <li>Hands-on application security training through the <a href="https://www.secureflag.com/owasp.html">SecureFlag Platform</a></li> 
       	<li>Networking and directory access</li>
         <li>Flexible online learning discounts</li>
         <li>Professional mentoring programs</li>


### PR DESCRIPTION
The link for secure flag was looking off so I added an href tag to fix the issue