### PR TITLE
Fix Important Links section

### DIFF
--- a/pages/projects/info.md
+++ b/pages/projects/info.md
@@ -1,5 +1,5 @@
 ### Important Links
 * [Project Handbook](https://owasp.org/www-pdf-archive/PROJECT_LEADER-HANDBOOK_2014.pdf)
 * [Start a New Project](https://owasporg.atlassian.net/servicedesk/customer/portal/7/create/70)
-* [OWASP Github](https://owasp.github.com)
+* [OWASP Github](https://github.com/OWASP)
 * [All Project Leaders](/projects/leaders/)


### PR DESCRIPTION
In `https://github.com/OWASP/owasp.github.io/blob/master/pages/projects/info.md` , Under the Important Links section on `https://owasp.org/projects` , I changed the link from [OWASP Github](https://owasp.github.com)  to [OWASP Github](https://github.com/OWASP)