### PR TITLE
Load Vue v2 explicitly instead of latest on pages with forms

### DIFF
--- a/pages/donate.md
+++ b/pages/donate.md
@@ -348,7 +348,7 @@ permalink: /donate/
 
 <script src="https://www.google.com/recaptcha/api.js?onload=vueRecaptchaApiLoaded&render=explicit"></script>
 <script src="https://js.stripe.com/v3"></script>
-<script src="https://unpkg.com/vue"></script>
+<script src="https://unpkg.com/vue@2/dist/vue.min.js"></script>
 <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
 <script src="https://unpkg.com/vue-recaptcha@1.3.0/dist/vue-recaptcha.min.js"></script>
 

--- a/pages/manage-membership.md
+++ b/pages/manage-membership.md
@@ -170,7 +170,7 @@ input[type='radio'] {
 {% endraw %}
 
 <script src="https://js.stripe.com/v3"></script>
-<script src="https://unpkg.com/vue"></script>
+<script src="https://unpkg.com/vue@2/dist/vue.min.js"></script>
 <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js"></script>
 

--- a/pages/membership.md
+++ b/pages/membership.md
@@ -161,7 +161,7 @@ permalink: /membership/
 {% endraw %}
 
 <script src="https://js.stripe.com/v3"></script>
-<script src="https://unpkg.com/vue"></script>
+<script src="https://unpkg.com/vue@2/dist/vue.min.js"></script>
 <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
 
 <script>


### PR DESCRIPTION
The app creation in the latest Vue (v3) has changed[1] and the forms no longer render with an error: `Uncaught TypeError: Vue is not a constructor`.

[1]: Compare https://v2.vuejs.org/v2/guide/#Declarative-Rendering and https://vuejs.org/guide/quick-start.html#without-build-tools

For example, here’s the current [Membership page](https://owasp.org/membership/) in the latest Google Chrome:

![Screenshot from 2022-02-07 15-36-31](https://user-images.githubusercontent.com/2400185/152798413-6aa72295-e973-460b-ad4c-e68f433bffcb.png)

vs the same page [with Vue v2](https://sainaen.github.com/owasp.github.io/membership/):

![Screenshot from 2022-02-07 15-37-13](https://user-images.githubusercontent.com/2400185/152798501-9b07ede5-fc6c-494e-8ac7-47c7df42ba38.png)
(note 404-s because the code expects to find its images in `/owasp.org/` repository which I don’t have, which is unrelated to Vue.)