### PR TITLE
[2020 -> 2022] Operating Plan, Budget & Goals

### DIFF
--- a/pages/governance.md
+++ b/pages/governance.md
@@ -8,14 +8,12 @@ permalink: /governance/
 
 The OWASP Foundation, Inc. is a United States 501(c)3 nonprofit charity governed by the Global Board and administered by its executive director, staff, and contractors. Volunteers contribute to the mission of the Foundation and lead projects and local chapters worldwide.
 
-## Goals for 2020
-1. Launch updated version of OWASP Top 10 by June 2020.
-1. Continue to optimize business operations to overachieve financial and membership targets.
-1. Manage two successful global conferences planning three in 2021.
-1. Launch Project Summits and AppSec Days to over 500 attendees
-1. Increase relevance and reputation of OWASP measured by 10% increase in web traffic.
-1. Improve satisfaction with OWASP by survey measured a 5% increase.
-1. Increase all classes of membership by 25%
+## Goals for 2022
+1. Continue adding Membership value and benefits; increasing student, individual, and lifetime memberships to 7000
+1. Run at least two Global AppSecs in 2022, including San Francisco
+1. Help drive project, event, membership, and outreach goals by implementing OWASP’s first marketing plan
+1. Complete a comprehensive customer experience (CX) improvement program
+1. Evaluate and replace our Association Management System with a cloud based system, preferably able to handle chapters and events to dramatically reduce costs
 
 ## Global Board of Directors
 - [Home Page and Upcoming Meetings](/www-board)

--- a/pages/governance.md
+++ b/pages/governance.md
@@ -35,8 +35,8 @@ The OWASP Foundation, Inc. is a United States 501(c)3 nonprofit charity governed
 
 ## Operations
 - [Foundational Staff](/corporate)
-- [Operating Plan for 2020](/www-staff/operating-plan/2020)
-- [Budget for 2020](/www-staff/budget/2020)
+- [Operating Plan for 2022](/www-staff/operating-plan/2022/)
+- [Budget for 2022](/www-staff/budget/2022)
 - [Staff Projects & Work plans](/www-staff)
 
 ## Code of Conduct


### PR DESCRIPTION
Outdated links pointing to 2020 pages. Updated to current year. 

Note: the page still has 2020's goals. Someone from the org may want to take a look.