### PR TITLE
Fix shortname for Top Ten: Top10

### DIFF
--- a/_data/project_mediatext.json
+++ b/_data/project_mediatext.json
@@ -86,7 +86,7 @@
     {
       "name": "Top Ten",
       "repo": "www-project-top-ten",
-      "shortname": "Top Ten",
+      "shortname": "Top10",
       "mediablurb": "Most critical security risks in web applications"
     },
     {


### PR DESCRIPTION
Our content root is also 'https://owasp.org/Top10'