### PR TITLE
Fixed memebership route to not index. issue: #230

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,1 +1,2 @@
-
+User-agent: *
+Disallow: /membership-success/


### PR DESCRIPTION
I have added the route 

`'/membership-success'`

 to robots.txt to disallow the indexing of it.
Is there anything else to do? please let me know


Reference: https://github.com/OWASP/owasp.github.io/issues/230