### PR TITLE
Redirect `/store` to  "Products" instead of "About" page

### DIFF
--- a/redirects/store.md
+++ b/redirects/store.md
@@ -4,6 +4,6 @@ title: Store Redirect
 permalink: /store/
 redirect_from: 
     - /store
-redirect_to: https://www.zazzle.com/store/owasp_foundation
+redirect_to: https://www.zazzle.com/store/owasp_foundation/products
 
 ---


### PR DESCRIPTION
This is what I'd expect to see after clicking on "Store" button.