### PR TITLE
Add AppSecUSA shortlinks

### DIFF
--- a/redirects/appsecus.md
+++ b/redirects/appsecus.md
@@ -1,0 +1,7 @@
+---
+
+title: Details on the upcoming AppSec USA conference!
+permalink: /appsecus
+redirect_to: https://owasp.glueup.com/event/owasp-2025-global-appsec-usa-washington-dc-131624/
+
+---

--- a/redirects/appsecusa.md
+++ b/redirects/appsecusa.md
@@ -1,0 +1,7 @@
+---
+
+title: Details on the upcoming AppSec USA conference!
+permalink: /appsecusa
+redirect_to: https://owasp.glueup.com/event/owasp-2025-global-appsec-usa-washington-dc-131624/
+
+---


### PR DESCRIPTION
creates shortlinks so that owasp.org/appsecus and owasp.org/appsecusa lead to the conference webpage