### PR TITLE
Propose a redirection to OSHP.

### DIFF
--- a/redirects/list_of_useful_http_headers.md
+++ b/redirects/list_of_useful_http_headers.md
@@ -1,0 +1,7 @@
+---
+
+title: List of useful HTTP headers
+permalink: /List_of_useful_HTTP_headers
+redirect_to: https://owasp.org/www-project-secure-headers/
+
+---


### PR DESCRIPTION
Hello,

This PR propose to redirect the following broken link to the [OWASP Secure Headers Project](https://owasp.org/www-project-secure-headers/) for information about HTTP Security headers:

https://owasp.org/index.php/List_of_useful_HTTP_headers

💡Source of the exchange on Slack:

![image](https://github.com/user-attachments/assets/83cd7e62-dc90-41c7-b0f4-6a557e7e6627)

🔬I propose such redirection, as the OSHP scope of work and focus, is the HTTP Security headers domains.

Thanks for your help 😉

