### PR TITLE
Fix error in OSHP redirection.

### DIFF
--- a/redirects/list_of_useful_http_headers.md
+++ b/redirects/list_of_useful_http_headers.md
@@ -2,6 +2,9 @@
 
 title: List of useful HTTP headers
 permalink: /List_of_useful_HTTP_headers
-redirect_to: https://owasp.org/www-project-secure-headers/
+redirect_from:
+  - /index.php/List_of_useful_HTTP_headers
+  - List-of-useful-HTTP-headers
+redirect_to: /www-project-secure-headers/
 
 ---

--- a/redirects/list_of_useful_http_headers.md
+++ b/redirects/list_of_useful_http_headers.md
@@ -4,7 +4,7 @@ title: List of useful HTTP headers
 permalink: /List_of_useful_HTTP_headers
 redirect_from:
   - /index.php/List_of_useful_HTTP_headers
-  - List-of-useful-HTTP-headers
+  - /List-of-useful-HTTP-headers
 redirect_to: /www-project-secure-headers/
 
 ---


### PR DESCRIPTION
Hello,

I noticed that the initial redirection proposed via PR #348 was not handling the expected case.

![image](https://github.com/user-attachments/assets/21a29088-8470-44fe-bc95-9bd49984f1d8)

Therefore, I updated the proposed redirection based on the redirection defined for the [Cheat Sheet Series](https://github.com/righettod/owasp.github.io/blob/main/redirects/cheatsheet.md).

Normally using this way, the redirection should now be OK

Thanks for your help 😉