### PR TITLE
Adding a short link to AIVSS

### DIFF
--- a/redirects/aivss.md
+++ b/redirects/aivss.md
@@ -1,0 +1,7 @@
+---
+
+title: AIVSS Redirect
+permalink: /aivss
+redirect_to: /www-project-artificial-intelligence-vulnerability-scoring-system/
+
+---


### PR DESCRIPTION
Add AIVSS redirect.

I followed these examples:

https://github.com/OWASP/owasp.github.io/blob/main/redirects/top10.md
https://github.com/OWASP/owasp.github.io/blob/main/redirects/api-top10.md