### PR TITLE
Adding a short link to AOS

### DIFF
--- a/redirects/aos.md
+++ b/redirects/aos.md
@@ -1,0 +1,7 @@
+---
+
+title: AOS Redirect
+permalink: /aos
+redirect_to: /www-project-agent-observability-standard/
+
+---


### PR DESCRIPTION
Add AOS redirect.

I followed this example:
https://github.com/OWASP/owasp.github.io/pull/353